### PR TITLE
Update licensing and improve CLI invocation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,22 @@
-MIT License
+Proprietary License
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Copyright (c) 2025 wx-cli contributors.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+All rights reserved. This software and its associated documentation files (the "Software") are proprietary and confidential.
+
+You may not, without the prior written consent of the copyright holder:
+
+- copy, modify, merge, publish, distribute, sublicense, sell, lease, loan, or
+  otherwise make available the Software or any derivative works;
+- use the Software for the benefit of any third party;
+- remove or obscure any proprietary notices contained in the Software.
+
+You may use the Software solely for internal evaluation purposes. Any other use
+requires a separate, written license agreement.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -79,3 +79,8 @@ wx forecast "Key West" --focus marine --trust-tools
 # Review alerts without AI triage
 wx alerts "Seattle"
 ```
+
+## License
+
+This project is distributed under a proprietary, all-rights-reserved license.
+Contact the maintainers for commercial or redistribution permissions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Mostly-AI Weather CLI"
 readme = "README.md"
 authors = [{name = "wx contributors"}]
-license = {text = "MIT"}
+license = {text = "All rights reserved"}
 requires-python = ">=3.11"
 dependencies = [
     "typer>=0.9",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+import pytest
+
+from wx import cli
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        ([], []),
+        (["How's", "weather?"], ["How's", "weather?"]),
+        (["forecast", "Paris"], ["", "forecast", "Paris"]),
+        (["--offline", "forecast", "Paris"], ["--offline", "", "forecast", "Paris"]),
+        (["--style", "brief", "forecast", "Paris"], ["--style", "brief", "", "forecast", "Paris"]),
+        (["", "forecast", "Paris"], ["", "forecast", "Paris"]),
+        (["--", "forecast"], ["--", "forecast"]),
+        (["risk", "--hazards", "wind"], ["", "risk", "--hazards", "wind"]),
+    ],
+)
+def test_normalize_invocation(argv, expected):
+    assert cli._normalize_invocation(argv) == expected


### PR DESCRIPTION
## Summary
- replace the MIT license with a proprietary "all rights reserved" license and update README/pyproject metadata
- fix the Typer CLI so subcommands work without manually supplying an empty question argument
- add unit coverage for the new invocation normalization helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dfc52272f8832f8b721c9d46b05e8f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved CLI argument handling for subcommands and options, ensuring consistent, predictable invocation across edge cases.

* Documentation
  * Added a License section to the README with details on proprietary, all-rights-reserved terms and how to request permissions.

* Chores
  * Updated project licensing from MIT to a proprietary license, including metadata changes.

* Tests
  * Added unit tests covering CLI invocation normalization scenarios to validate behavior with empty args, quoted strings, flags, and separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->